### PR TITLE
Add project: did:aip

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -398,6 +398,13 @@ projects:
   - name: universal-registrar
     github_id: decentralized-identity/universal-registrar
     category: dids
+  - name: "did:aip (Agent Internet Protocol)"
+    github_id: dr-wilson-empty/aip-beta
+    npm_id: "@aipagents/did-resolver"
+    dockerhub_id: ghcr.io/dr-wilson-empty/driver-did-aip
+    description: W3C-conformant, Solana-anchored DID method and open-source resolver for autonomous AI agent identity
+    homepage: https://aipagents.xyz
+    category: dids
   - name: did-webs
     github_id: trustoverip/tswg-did-method-webs-specification
     category: dids


### PR DESCRIPTION
Adds did:aip to the Decentralized Identifiers category.

did:aip is a W3C DID Core 1.0 conformant, Solana-anchored DID method for autonomous AI agent identity: an identifier of the form did:aip:{owner_pubkey}:{agent_id} resolves to a Solana program-derived address. It ships an open-source MIT TypeScript resolver (npm `@aipagents/did-resolver`) and a DIF Universal Resolver driver, and is registered in the W3C did-extensions DID method registry.

- name: did:aip (Agent Internet Protocol)
- github_id: dr-wilson-empty/aip-beta
- category: dids

Note: this is a different project from the existing `aip-identity` entry (The-Nexus-Guard/aip), a different DID method with an unrelated codebase.
